### PR TITLE
Fixed error when running tests

### DIFF
--- a/spec/blather/roster_item_spec.rb
+++ b/spec/blather/roster_item_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), *%w[.. spec_helper])
+require File.join(File.dirname(__FILE__), *%w[.. .. spec_helper])
 
 describe Blather::RosterItem do
   it 'can be initialized with Blather::JID' do


### PR DESCRIPTION
I'm not sure if this is an isolated problem related to my specific configuration (Ubuntu 10.04, ruby 1.9.2) or not. But, changing the require path for spec_helper in spec/blather/roster_item_spec fixed the exception below:

$ rake
(in /home/vanstee/Code/blather)
/home/vanstee/.rvm/rubies/ruby-1.9.2-p0/bin/ruby -I"lib:lib:spec" "/home/vanstee/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "spec/blather/roster_item_spec.rb" "spec/blather/stanza_spec.rb" "spec/blather/stream/parser_spec.rb" "spec/blather/stream/client_spec.rb" "spec/blather/stream/component_spec.rb" "spec/blather/client/dsl/pubsub_spec.rb" "spec/blather/client/dsl_spec.rb" "spec/blather/client/client_spec.rb" "spec/blather/stanza/presence/subscription_spec.rb" "spec/blather/stanza/presence/status_spec.rb" "spec/blather/stanza/discos/disco_info_spec.rb" "spec/blather/stanza/discos/disco_items_spec.rb" "spec/blather/stanza/pubsub_spec.rb" "spec/blather/stanza/pubsub_owner/purge_spec.rb" "spec/blather/stanza/pubsub_owner/delete_spec.rb" "spec/blather/stanza/iq_spec.rb" "spec/blather/stanza/x_spec.rb" "spec/blather/stanza/pubsub/subscription_spec.rb" "spec/blather/stanza/pubsub/affiliations_spec.rb" "spec/blather/stanza/pubsub/items_spec.rb" "spec/blather/stanza/pubsub/subscriptions_spec.rb" "spec/blather/stanza/pubsub/retract_spec.rb" "spec/blather/stanza/pubsub/event_spec.rb" "spec/blather/stanza/pubsub/create_spec.rb" "spec/blather/stanza/pubsub/unsubscribe_spec.rb" "spec/blather/stanza/pubsub/publish_spec.rb" "spec/blather/stanza/pubsub/subscribe_spec.rb" "spec/blather/stanza/iq/vcard_query_spec.rb" "spec/blather/stanza/iq/query_spec.rb" "spec/blather/stanza/iq/roster_spec.rb" "spec/blather/stanza/iq/command_spec.rb" "spec/blather/stanza/message_spec.rb" "spec/blather/stanza/presence_spec.rb" "spec/blather/stanza/pubsub_owner_spec.rb" "spec/blather/xmpp_node_spec.rb" "spec/blather/core_ext/nokogiri_spec.rb" "spec/blather/errors/stanza_error_spec.rb" "spec/blather/errors/stream_error_spec.rb" "spec/blather/errors/sasl_error_spec.rb" "spec/blather/errors_spec.rb" "spec/blather/roster_spec.rb" "spec/blather/jid_spec.rb" 
internal:lib/rubygems/custom_require:29:in `require': no such file to load -- spec/blather/../spec_helper (LoadError)
    from <internal:lib/rubygems/custom_require>:29:in`require'
    from spec/blather/roster_item_spec.rb:1:in `<top (required)>'
    from /home/vanstee/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in`load'
    from /home/vanstee/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `block in <main>'
    from /home/vanstee/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in`each'
    from /home/vanstee/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake/rake_test_loader.rb:5:in `<main>'
rake aborted!
Command failed with status (1): [/home/vanstee/.rvm/rubies/ruby-1.9.2-p0/bi...]

(See full trace by running task with --trace)
