### PR TITLE
Fix gem deps and Rakefile for jruby and rbx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,11 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in testgem.gemspec
 gemspec
 
-if RUBY_PLATFORM =~ /darwin/
+if RUBY_PLATFORM =~ /darwin/ && (!defined?(RUBY_ENGINE) || RUBY_ENGINE != 'rbx')
   gem 'growl_notify'
   gem 'rb-fsevent'
 end
 
-gem 'bluecloth' unless RUBY_PLATFORM =~ /java/
+unless (RUBY_PLATFORM =~ /java/ || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'))
+  gem 'bluecloth'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -11,20 +11,23 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-require 'rcov/rcovtask'
-Rcov::RcovTask.new do |test|
-  test.libs << 'spec'
-  test.pattern = 'spec/**/*_spec.rb'
-  test.rcov_opts += ['--exclude \/Library\/Ruby,spec\/', '--xrefs']
-  test.verbose = true
-end
+begin
+  require 'rcov/rcovtask'
+  Rcov::RcovTask.new do |test|
+    test.libs << 'spec'
+    test.pattern = 'spec/**/*_spec.rb'
+    test.rcov_opts += ['--exclude \/Library\/Ruby,spec\/', '--xrefs']
+    test.verbose = true
+  end
 
-require 'yard'
-YARD::Tags::Library.define_tag 'Blather handler', :handler, :with_name
-YARD::Templates::Engine.register_template_path 'yard/templates'
+  require 'yard'
+  YARD::Tags::Library.define_tag 'Blather handler', :handler, :with_name
+  YARD::Templates::Engine.register_template_path 'yard/templates'
 
-YARD::Rake::YardocTask.new(:doc) do |t|
-  t.options = ['--no-private', '-m', 'markdown', '-o', './doc/public/yard']
+  YARD::Rake::YardocTask.new(:doc) do |t|
+    t.options = ['--no-private', '-m', 'markdown', '-o', './doc/public/yard']
+  end
+rescue LoadError
 end
 
 task :default => :test

--- a/blather.gemspec
+++ b/blather.gemspec
@@ -28,8 +28,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", ["~> 1.7.1"]
   s.add_development_dependency "mocha", ["~> 0.9.12"]
   s.add_development_dependency "bundler", ["~> 1.0.0"]
-  s.add_development_dependency "rcov", ["~> 0.9.9"]
-  s.add_development_dependency "yard", ["~> 0.6.1"]
+  if !defined?(RUBY_ENGINE) || RUBY_ENGINE != 'rbx'
+    s.add_development_dependency "rcov", ["~> 0.9.9"]
+    s.add_development_dependency "yard", ["~> 0.6.1"]
+  end
+  s.add_development_dependency "jruby-openssl", ["~> 0.7.4"] if RUBY_PLATFORM =~ /java/
   s.add_development_dependency "rake"
   s.add_development_dependency "guard-minitest"
 end


### PR DESCRIPTION
This patch fixes the dependencies for jruby and rbx. Tests now pass on rbx. JRuby is still failing but it's no longer due to dependendencies. 
