### PR TITLE
Eventmachine 1.0

### DIFF
--- a/blather.gemspec
+++ b/blather.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = %w{--charset=UTF-8}
   s.extra_rdoc_files = %w{LICENSE README.md}
 
-  s.add_dependency "eventmachine", [">= 0.12.6", "<= 1.0.0beta4"]
+  s.add_dependency "eventmachine", [">= 0.12.6"]
   s.add_dependency "nokogiri", ["~> 1.4.0"]
   s.add_dependency "niceogiri", [">= 0.0.4"]
   s.add_dependency "activesupport", [">= 3.0.7"]


### PR DESCRIPTION
Hi,

Any chance to update the blather gemspec to allow eventmachine from 0.12.6 to <= 1.0.0beta4 ?

I ran the test suite with the latest 1.0.0beta of eventmachine, and all tests passed (MRI 1.8.7 and 1.9.2). That would help integrate blather in projects that use other EM-based gems by @igrigorik as they often require eventmachine >= 1.0.0 to work.

Thanks,

Cyril
