### PR TITLE
Fix: Disable connection timeout timer if client deliberately disconnects

### DIFF
--- a/lib/blather/stream.rb
+++ b/lib/blather/stream.rb
@@ -149,7 +149,7 @@ module Blather
     # @private
     def connection_completed
       if @connect_timeout
-        EM::Timer.new @connect_timeout do
+        @connect_timer = EM::Timer.new @connect_timeout do
           raise ConnectionTimeout, "Stream timed out after #{@connect_timeout} seconds." unless started?
         end
       end
@@ -198,6 +198,7 @@ module Blather
       raise NoConnection unless @inited
       raise ConnectionFailed unless @connected
 
+      @connect_timer.cancel if @connect_timer
 #      @keepalive.cancel
       @state = :stopped
       @client.receive_data @error if @error


### PR DESCRIPTION
With the introduction of the connection timeout facility in 0.5.11, clients disconnect will have the `ConnectionTimeout` error raised even if the connection was disconnected deliberately by the client.

Here's a quick script to demonstrate the problem:

``` ruby
require 'rubygems'
require 'blather/client/client'

timeout = 10
jid = "theozaurus@jabber.org"
password = "foobar"

def log(message)
  puts "#{Time.now}: #{message}"
end

trap(:INT ){ EM.stop }
trap(:TERM){ EM.stop }
EM.run do
  client = Blather::Client.setup jid, password, nil, nil, nil, timeout

  client.register_handler(:ready) do
    log "Client connected, so will now disconnect"
    EM::PeriodicTimer.new 1 do
      log "Reactor loop alive"
    end
    client.close
  end

  client.register_handler(:disconnected) do
    log "Disconnected client"
    true # Prevent reactor loop from stopping
  end

  log "Connection timeout set to #{timeout} seconds"
  client.connect
end
```

This produces the output:

```
$ ruby test-blather.rb 
2012-01-25 13:38:32 +0000: Connection timeout set to 10 seconds
2012-01-25 13:38:34 +0000: Client connected, so will now disconnect
2012-01-25 13:38:34 +0000: Disconnected client
2012-01-25 13:38:35 +0000: Reactor loop alive
2012-01-25 13:38:36 +0000: Reactor loop alive
2012-01-25 13:38:38 +0000: Reactor loop alive
2012-01-25 13:38:39 +0000: Reactor loop alive
2012-01-25 13:38:40 +0000: Reactor loop alive
2012-01-25 13:38:41 +0000: Reactor loop alive
2012-01-25 13:38:42 +0000: Reactor loop alive
/Users/theo/.rvm/gems/ruby-1.9.2-p290@blather/gems/blather-0.5.12/lib/blather/stream.rb:153:in `block in connection_completed': Stream timed out after 10 seconds. (Blather::Stream::ConnectionTimeout)
    from /Users/theo/.rvm/gems/ruby-1.9.2-p290@blather/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `call'
    from /Users/theo/.rvm/gems/ruby-1.9.2-p290@blather/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `run_machine'
    from /Users/theo/.rvm/gems/ruby-1.9.2-p290@blather/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `run'
    from test-blather.rb:14:in `<main>'
```

The fix attached here I believe solves the problem, but I am not certain if it completely defeats the point of connection timeout. I am assuming that `#unbind` will only get called in the case of a deliberate disconnect. Can someone confirm this?
