### PR TITLE
Ensure that JIDs in roster item stanzas are stripped

### DIFF
--- a/lib/blather/stanza/iq/roster.rb
+++ b/lib/blather/stanza/iq/roster.rb
@@ -92,14 +92,14 @@ class Iq
       #
       # @return [Blather::JID, nil]
       def jid
-        (j = self[:jid]) ? JID.new(j).stripped : nil
+        (j = self[:jid]) ? JID.new(j) : nil
       end
 
       # Set the JID of the item
       #
       # @param [Blather::JID, String, nil] jid the new JID
       def jid=(jid)
-        write_attr :jid, jid
+        write_attr :jid, (jid.nil?) ? nil : JID.new(jid).stripped
       end
 
       # Get the item name

--- a/spec/blather/stanza/iq/roster_spec.rb
+++ b/spec/blather/stanza/iq/roster_spec.rb
@@ -80,7 +80,7 @@ describe Blather::Stanza::Iq::Roster::RosterItem do
     n[:subscription] = 'both'
 
     i = Blather::Stanza::Iq::Roster::RosterItem.new n
-    i.jid.must_equal Blather::JID.new('n@d/r').stripped
+    i.jid.must_equal Blather::JID.new('n@d/r')
     i.subscription.must_equal :both
   end
 


### PR DESCRIPTION
This is a touchy issue -- a literal read of RFC6121 doesn't 
preclude adding roster items with a resource component, although
numerous discussions suggest that this is due more to pedantism
than any typical usefulness. This patch ensures that JIDs are
stripped before going over the wire, so that we only
ever talk in bare JIDs to the server. It's a judgement call, but the 
general consensus seems to be that resources in a transmitted roster
should generally be avoided (see [1]).

Note that because this is done in the stanza and not in the 
roster itself, you're free to store items in your local 
Roster however you'd like. All this changes is what's on the wire.

[1] http://www.ietf.org/mail-archive/web/xmpp/current/msg02590.html
