### PR TITLE
Allow joining conferences and sending messages to the conference.

### DIFF
--- a/lib/blather/client/dsl.rb
+++ b/lib/blather/client/dsl.rb
@@ -206,12 +206,23 @@ module Blather
       client.write stanza
     end
 
+    # Helper method to join a conference.
+    #
+    # @param [Blather::JID, #to_s] join the conference at this JID.
+    # @param [#to_s] the nickname to join the conference as.
+    def join(conference, nickname)
+      join = Blather::Stanza::Presence::MUC.new
+      join.to = "#{conference}/#{nickname}"
+      client.write join
+    end
+
     # Helper method to make sending basic messages easier
     #
     # @param [Blather::JID, #to_s] to the JID of the message recipient
     # @param [#to_s] msg the message to send
-    def say(to, msg)
-      client.write Blather::Stanza::Message.new(to, msg)
+    # @param [#to_sym] the stanza method to use
+    def say(to, msg, using = :chat)
+      client.write Blather::Stanza::Message.new(to, msg, using)
     end
 
     # The JID according to the server


### PR DESCRIPTION
Hey,

I'd patched in two methods to the DSL at run time so that blather could join a conference room and respond to people within the room and I thought I'd contribute this back. I'm not 100% if it's correct, but it seems to work for me. I haven't modified the rspec just yet, as I'm still fairly new to using it. To send a message to the joined room, use `:groupchat` instead of `:chat` (or nothing) as the last argument to `#say`.

Hope this helps.

Cheers,
Joshua K
