### PR TITLE
Ping Pong example update

### DIFF
--- a/examples/ping_pong.rb
+++ b/examples/ping_pong.rb
@@ -6,9 +6,9 @@ module Ping
   extend Blather::DSL
   def self.run; client.run; end
 
-  setup 'echo@jabber.local/ping', 'echo'
+  setup 'ping@your.jabber.server', 'password'
 
-  status :from => Blather::JID.new('echo@jabber.local/pong') do |s|
+  status :from => /pong@your\.jabber\.server/ do |s|
     puts "serve!"
     say s.from, 'ping'
   end
@@ -23,7 +23,7 @@ module Pong
   extend Blather::DSL
   def self.run; client.run; end
 
-  setup 'echo@jabber.local/pong', 'echo'
+  setup 'pong@your.jabber.server', 'password'
   message :chat?, :body => 'ping' do |m|
     puts "pong!"
     say m.from, 'pong'


### PR DESCRIPTION
The Ping Pong example does not work by just changing the credentials for both accounts.

After some investigation I realized that JID objects are compared using `==` and `eql()` by using node, domain and resource. Because of this, a newly instanciated JID (which does not have resource) will not be equal to a JID coming from a presence/status stanza.

This updated example works for me.

Please let me know if I can/should change anything.
