### PR TITLE
Downcase JID in Roster

### DIFF
--- a/lib/blather/roster.rb
+++ b/lib/blather/roster.rb
@@ -106,7 +106,7 @@ module Blather
   private
     # Creates a stripped jid
     def self.key(jid)
-      JID.new(jid).stripped.to_s
+      JID.new(jid).stripped.to_s.downcase
     end
 
     # Instance method to wrap around the class method


### PR DESCRIPTION
Downcase JID in Roster as GTalk increasingly mixes Up.Case@gmail.com and up.case@gmail.com jid, depending on client used (Up.Case@gmail.com with Trillian / GTalk client and up.case@gmail.com with GMail client).
