### PR TITLE
Exceptions removal & Removed stop EM loop

### DIFF
--- a/lib/blather/client/client.rb
+++ b/lib/blather/client/client.rb
@@ -180,7 +180,7 @@ module Blather
 
     # @private
     def unbind
-      call_handler_for(:disconnected, nil) || (EM.reactor_running? && EM.stop)
+      call_handler_for(:disconnected, nil)
     end
 
     # @private

--- a/lib/blather/stream.rb
+++ b/lib/blather/stream.rb
@@ -149,7 +149,7 @@ module Blather
     def connection_completed
       if @connect_timeout
         @connect_timer = EM::Timer.new @connect_timeout do
-          raise ConnectionTimeout, "Stream timed out after #{@connect_timeout} seconds." unless started?
+          close_connection unless started?
         end
       end
       @connected = true
@@ -190,9 +190,6 @@ module Blather
     # @private
     def unbind
       cleanup
-
-      raise NoConnection unless @inited
-      raise ConnectionFailed unless @connected
 
       @state = :stopped
       @client.receive_data @error if @error


### PR DESCRIPTION
- Blather shouldn't stop EM  
  Blather could be used with other libs inside common EM loop. Or just more that one instance of Blather client could be running.
- Exceptions shouldn't be used with EventMachine  
  Moreover there is nothing happened here. Just close the connection and if it's required there is an ability to overlap unbind method to react on it.
  This patch helps me to run multiple Blather clients in a single EM loop and restart them on connection failure.

``` ruby
disconnected do
   EM::add_timer(15){ self.run }
end
```
