### PR TITLE
Add the ability to set the workqueue size

### DIFF
--- a/lib/blather/client/client.rb
+++ b/lib/blather/client/client.rb
@@ -34,7 +34,8 @@ module Blather
   class Client
     attr_reader :jid,
                 :roster,
-                :caps
+                :caps,
+                :queue_size
 
     # Create a new client and set it up
     #
@@ -43,11 +44,16 @@ module Blather
     # @param [String] host if this isn't set it'll be resolved off the JID's
     # domain
     # @param [Fixnum, String] port the port to connect to.
+    # @param [Hash] options a list of options to create the client with
+    # @option options [Number] :workqueue_count (5) the number of threads used to process incoming XMPP messages.
+    #   If this parameter is specified with 0, no background threads are used;
+    #   instead stanzas are handled in the same process that the Client is running in.
     #
     # @return [Blather::Client]
-    def self.setup(jid, password, host = nil, port = nil, certs = nil, connect_timeout = nil)
-      self.new.setup(jid, password, host, port, certs, connect_timeout)
+    def self.setup(jid, password, host = nil, port = nil, certs = nil, connect_timeout = nil, options = {})
+      self.new.setup(jid, password, host, port, certs, connect_timeout, options)
     end
+
 
     def initialize  # @private
       @state = :initializing
@@ -58,10 +64,7 @@ module Blather
       @filters = {:before => [], :after => []}
       @roster = Roster.new self
       @caps = Stanza::Capabilities.new
-
-      @handler_queue = GirlFriday::WorkQueue.new :handle_stanza, :size => 5 do |stanza|
-        handle_data stanza
-      end
+      @queue_size = 5
 
       setup_initial_handlers
     end
@@ -185,7 +188,11 @@ module Blather
 
     # @private
     def receive_data(stanza)
-      @handler_queue << stanza
+      if handler_queue
+        handler_queue << stanza
+      else
+        handle_data stanza
+      end
     end
 
     def handle_data(stanza)
@@ -202,14 +209,23 @@ module Blather
     end
 
     # @private
-    def setup(jid, password, host = nil, port = nil, certs = nil, connect_timeout = nil)
+    def setup(jid, password, host = nil, port = nil, certs = nil, connect_timeout = nil, options = {})
       @jid = JID.new(jid)
       @setup = [@jid, password]
       @setup << host
       @setup << port
       @setup << certs
       @setup << connect_timeout
+      @queue_size = options[:workqueue_count] || 5
       self
+    end
+
+    # @private
+    def handler_queue
+      return if queue_size == 0
+      @handler_queue ||= GirlFriday::WorkQueue.new :handle_stanza, :size => queue_size do |stanza|
+        handle_data stanza
+      end
     end
 
     protected


### PR DESCRIPTION
Part 1 of 2 to help address https://github.com/adhearsion/blather/issues/139
- Allow users to set the size of the GirlFriday::WorkQueue by setting
  Blather::Client.queue_size.
- The queue size is copied from the class at instance initialization time,
  so it is possible to make clients with different queue sizes if necessary.
- If the queue size is 0, then #receive_data will process the incoming stanza
  immediately.

Note: as the initializer has no arguments, we felt a class method was the best option here. I figure the most likely case is that a given application will want the same queue size for all of its clients, but if there's a better way to specify that, please let me know.
