### PR TITLE
Shutdown workqueue on close

### DIFF
--- a/lib/blather/client/client.rb
+++ b/lib/blather/client/client.rb
@@ -174,7 +174,7 @@ module Blather
       EM.next_tick {
         handler_queue.shutdown if handler_queue
         @handler_queue = nil
-        self.stream.close_connection_after_writing
+        self.stream.close_connection_after_writing if connected?
       }
     end
 

--- a/spec/blather/client/client_spec.rb
+++ b/spec/blather/client/client_spec.rb
@@ -125,30 +125,52 @@ describe Blather::Client do
     before do
       EM.stubs(:next_tick).yields
       subject.setup 'me.com', 'secret'
-      subject.post_init stream, Blather::JID.new('me.com')
     end
 
-    it 'writes to the connection the closes when #close is called' do
-      stream.expects(:close_connection_after_writing)
-      subject.close
+    context "without a setup stream" do
+      it "does not close the connection" do
+        stream.expects(:close_connection_after_writing).never
+        subject.close
+      end
     end
 
-    it 'shuts down the workqueue' do
-      stream.stubs(:close_connection_after_writing)
-      subject.handler_queue.expects(:shutdown)
-      subject.close
-    end
+    context "when a stream is setup" do
+      let(:stream_stopped) { false }
+      before do
+        subject.post_init stream, Blather::JID.new('me.com')
+        stream.stubs(:stopped? => stream_stopped)
+      end
 
-    it 'forces the work queue to be re-created when referenced' do
-      stream.stubs(:close_connection_after_writing)
-      subject.close
+      context "when the stream is stopped" do
+        let(:stream_stopped) { true }
 
-      fake_queue = stub('GirlFriday::WorkQueue')
-      GirlFriday::WorkQueue.expects(:new)
+        it "does not close the connection, since it's already closed" do
+          stream.expects(:close_connection_after_writing).never
+        end
+      end
+
+      it 'writes to the connection the closes when #close is called' do
+        stream.expects(:close_connection_after_writing)
+        subject.close
+      end
+
+      it 'shuts down the workqueue' do
+        stream.stubs(:close_connection_after_writing)
+        subject.handler_queue.expects(:shutdown)
+        subject.close
+      end
+
+      it 'forces the work queue to be re-created when referenced' do
+        stream.stubs(:close_connection_after_writing)
+        subject.close
+
+        fake_queue = stub('GirlFriday::WorkQueue')
+        GirlFriday::WorkQueue.expects(:new)
         .with(:handle_stanza, :size => subject.queue_size)
-        .returns(fake_queue)
+          .returns(fake_queue)
 
-      subject.handler_queue.should == fake_queue
+        subject.handler_queue.should == fake_queue
+      end
     end
   end
 


### PR DESCRIPTION
Part 2 of 2 to help address https://github.com/adhearsion/blather/issues/139

Depends on https://github.com/adhearsion/blather/pull/140 (for lazy initialization of `handler_queue`)

Since the `handler_queue` is lazily initialized, all we have to do at connection close time is shutdown the queue and nil it out. Any subsequent reference (such as in `#receive_data`) will automatically re-create it, if necessary.
