### PR TITLE
delegate to_xml (with options) to the node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * Bugfix: make to_xml method for errors accept formatting options to prevent exception when used with client.write
 
 # [v1.0.0](https://github.com/adhearsion/blather/compare/v0.8.8...v1.0.0) - [2014-02-10](https://rubygems.org/gems/blather/versions/1.0.0)
   * Stable API promise

--- a/lib/blather/errors/stanza_error.rb
+++ b/lib/blather/errors/stanza_error.rb
@@ -95,8 +95,8 @@ class StanzaError < BlatherError
   # Convert the object to a proper node then convert it to a string
   #
   # @return [String]
-  def to_xml
-    to_node.to_s
+  def to_xml(opts={})
+    to_node.to_xml(opts)
   end
 
   # @private

--- a/lib/blather/errors/stream_error.rb
+++ b/lib/blather/errors/stream_error.rb
@@ -69,8 +69,8 @@ class StreamError < BlatherError
   # Convert the object to a proper node then convert it to a string
   #
   # @return [String]
-  def to_xml
-    to_node.to_s
+  def to_xml(opts={})
+    to_node.to_xml(opts)
   end
 
   # @private

--- a/spec/blather/errors/stanza_error_spec.rb
+++ b/spec/blather/errors/stanza_error_spec.rb
@@ -94,6 +94,14 @@ describe Blather::StanzaError do
       doc.xpath("/message/error/err_ns:text[.='the server has experienced a misconfiguration']", :err_ns => Blather::StanzaError::STANZA_ERR_NS).should_not be_empty
       doc.xpath("/message/error/extra_ns:extra-error[.='Blather Error']", :extra_ns => 'blather:stanza:error').should_not be_empty
     end
+
+    describe '#to_xml' do
+      it 'accepts optional formatting options' do
+        # without spaces
+        string = @err.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML)
+        expect(string).to eq '<message type="error" from="error@jabber.local"><body>test message</body><error type="cancel"><internal-server-error xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/><text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">the server has experienced a misconfiguration</text><extra-error xmlns="blather:stanza:error">Blather Error</extra-error></error></message>'
+      end
+    end
   end
 
   describe 'each XMPP stanza error type' do

--- a/spec/blather/errors/stream_error_spec.rb
+++ b/spec/blather/errors/stream_error_spec.rb
@@ -72,6 +72,15 @@ describe 'Blather::StreamError when instantiated' do
     doc.xpath("//err_ns:text[.='the server has experienced a misconfiguration']", :err_ns => Blather::StreamError::STREAM_ERR_NS).should_not be_empty
     doc.xpath("//err_ns:extra-error[.='Blather Error']", :err_ns => 'blather:stream:error').should_not be_empty
   end
+
+
+  describe '#to_xml' do
+    it 'accepts optional formatting options' do
+      # without spaces
+      string = @err.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML)
+      expect(string).to eq "<stream:error xmlns:stream=\"http://etherx.jabber.org/streams\"><internal-server-error xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\"/><text xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\">the server has experienced a misconfiguration</text><extra-error xmlns=\"blather:stream:error\">Blather Error</extra-error></stream:error>"
+    end
+  end
 end
 
 describe 'Each XMPP stream error type' do


### PR DESCRIPTION
Instead of defining `to_xml` as `node.to_s` call `node.to_xml`, which also accepts an options hash to control the output.  With this change the `to_xml` method for errors behaves just like any other stanza's `to_xml` method.
