### PR TITLE
Fix NoMethodError when server doesn't provide roster service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
   * Bugfix: Allow sending errors to the wire directly with correct formatting (previously raised)
+  * Bugfix: Don't pass service unavailable response to be processed as roster in client_post_init
 
 # [v1.0.0](https://github.com/adhearsion/blather/compare/v0.8.8...v1.0.0) - [2014-02-10](https://rubygems.org/gems/blather/versions/1.0.0)
   * Stable API promise

--- a/lib/blather/client/client.rb
+++ b/lib/blather/client/client.rb
@@ -277,7 +277,7 @@ module Blather
 
     def client_post_init
       write_with_handler Stanza::Iq::Roster.new do |node|
-        roster.process node
+        roster.process(node) unless node.error?
         write @status
         ready!
       end

--- a/spec/blather/client/client_spec.rb
+++ b/spec/blather/client/client_spec.rb
@@ -461,6 +461,27 @@ describe Blather::Client do
       subject.register_handler(:ready) { ready.call }
       subject.post_init stream, Blather::JID.new('n@d/r')
     end
+
+    it 'gracefully handles service unavailability upon requesting the roster' do
+      result_roster = Blather::Stanza::Iq.parse <<-XML
+        <iq type="error" to="n@d/r">
+          <error type="cancel">
+            <service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/>
+          </error>
+        </iq>
+      XML
+
+      stream.stubs(:send).with do |s|
+        result_roster.id = s.id
+        subject.receive_data result_roster
+        true
+      end
+
+      ready = mock
+      ready.expects(:call)
+      subject.register_handler(:ready) { ready.call }
+      subject.post_init stream, Blather::JID.new('n@d/r')
+    end
   end
 
   describe 'filters' do


### PR DESCRIPTION
Hey,

I was doing some experiments with my servers roster code and stumbled upon an error when the server did not provide any rosters at all, despite the response stating that correctly.
The first commit adds a spec to illustrate the problem, the second commit introduces a simple fix.

Kind regards
Christoph