### PR TITLE
Implement Blather::Roster#version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
   * Bugfix: Properly sort resources with the same priority but different status
+  * Feature: Implement Blather::Roster#version, which returns version of last processed roster stanza
 
 # [v1.1.4](https://github.com/adhearsion/blather/compare/v1.1.4...v1.1.4) - [2015-06-12](https://rubygems.org/gems/blather/versions/1.1.4)
   * Bugfix: Typo in passing through connection options

--- a/lib/blather/roster.rb
+++ b/lib/blather/roster.rb
@@ -5,6 +5,8 @@ module Blather
   class Roster
     include Enumerable
 
+    attr_reader :version
+
     # Create a new roster
     #
     # @param [Blather::Stream] stream the stream the roster should use to
@@ -15,7 +17,7 @@ module Blather
     def initialize(stream, stanza = nil)
       @stream = stream
       @items = {}
-      stanza.items.each { |i| push i, false } if stanza
+      process(stanza) if stanza
     end
 
     # Process any incoming stanzas and either adds or removes the
@@ -23,6 +25,7 @@ module Blather
     #
     # @param [Blather::Stanza::Iq::Roster] stanza a roster stanza
     def process(stanza)
+      @version = stanza.version
       stanza.items.each do |i|
         case i.subscription
         when :remove then @items.delete(key(i.jid))

--- a/lib/blather/stanza/iq/roster.rb
+++ b/lib/blather/stanza/iq/roster.rb
@@ -42,6 +42,13 @@ class Iq
       end
     end
 
+    # The provided roster version if available
+    #
+    # @return [String]
+    def version
+      query[:ver]
+    end
+
     # # RosterItem Fragment
     #
     # Individual roster items.

--- a/spec/blather/roster_spec.rb
+++ b/spec/blather/roster_spec.rb
@@ -6,14 +6,15 @@ describe Blather::Roster do
     @stream.stubs(:write)
 
     @stanza = mock()
-    items = []; 4.times { |n| items << Blather::JID.new("n@d/#{n}r") }
+    items = 4.times.map { |n| Blather::Stanza::Iq::Roster::RosterItem.new(jid: "n@d/#{n}r") }
     @stanza.stubs(:items).returns(items)
+    @stanza.stubs(:version).returns('24d091d0dcfab1b3')
 
     @roster = Blather::Roster.new(@stream, @stanza)
   end
 
   it 'initializes with items' do
-    @roster.items.map { |_,i| i.jid.to_s }.should == (@stanza.items.map { |i| i.stripped.to_s }.uniq)
+    @roster.items.map { |_,i| i.jid.to_s }.should == (@stanza.items.map { |i| i.jid.stripped.to_s }.uniq)
   end
 
   it 'processes @stanzas with remove requests' do
@@ -103,5 +104,9 @@ describe Blather::Roster do
       'group2' => [item1],
       'group3' => [item2]
     })
+  end
+
+  it 'has a version' do
+    expect(@roster.version).to eq @stanza.version
   end
 end

--- a/spec/blather/stanza/iq/roster_spec.rb
+++ b/spec/blather/stanza/iq/roster_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 def roster_xml
 <<-XML
 <iq to='juliet@example.com/balcony' type='result' id='roster_1'>
-  <query xmlns='jabber:iq:roster'>
+  <query xmlns='jabber:iq:roster' ver='3bb607aa4fa0bc9e'>
     <item jid='romeo@example.net'
           name='Romeo'
           subscription='both'>
@@ -37,6 +37,12 @@ describe Blather::Stanza::Iq::Roster do
 
   it 'can be created with #import' do
     Blather::XMPPNode.parse(roster_xml).should be_instance_of Blather::Stanza::Iq::Roster
+  end
+
+  it 'retrieves version' do
+    n = parse_stanza roster_xml
+    r = Blather::Stanza::Iq::Roster.new.inherit n.root
+    expect(r.version).to eq '3bb607aa4fa0bc9e'
   end
 end
 


### PR DESCRIPTION
It returns the version attribute of the last processed roster stanza.

I had to change `Roster#initialize` to use `#process`, which in turn required the change in the spec, where previously an array of JIDs was passed in as the stanzas items.
This particular spec seems a bit off anyway, the JIDs in a `jabber:iq:roster` stanza do not contain any resource, but this was a bit out this PRs scope.

Cheers!