### PR TITLE
Switch from girl_friday to sucker_punch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Bugfix: Fix unsafe threaded use of @tmp_handlers in Blather::Client
   * Feature: Bump RSpec to 3.x and convert specs with Transpec
   * Feature: Bump Mocha version to 1.x
+  * Feature: Switch from girl_friday to sucker_punch
 
 # [v1.2.0](https://github.com/adhearsion/blather/compare/v1.1.4...v1.2.0) - [2016-01-07](https://rubygems.org/gems/blather/versions/1.2.0)
   * Bugfix: Properly sort resources with the same priority but different status

--- a/blather.gemspec
+++ b/blather.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", ["~> 1.5", ">= 1.5.6", "<= 1.6.1"]
   s.add_dependency "niceogiri", ["~> 1.0"]
   s.add_dependency "activesupport", [">= 2.3.11"]
-  s.add_dependency "girl_friday"
+  s.add_dependency "sucker_punch", ["~> 2.0"]
 
   s.add_development_dependency "bundler", ["~> 1.0"]
   s.add_development_dependency "rake"

--- a/lib/blather.rb
+++ b/lib/blather.rb
@@ -8,7 +8,7 @@
   digest/sha1
   logger
   openssl
-  girl_friday
+  sucker_punch
 
   active_support/core_ext/class/attribute
   active_support/core_ext/object/blank

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'blather'
 require 'countdownlatch'
+require 'sucker_punch/testing/inline'
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
@@ -9,7 +10,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.before(:each) do
-    GirlFriday::WorkQueue.immediate!
     Blather::Stream::Parser.debug = true
     Blather.logger = Logger.new($stdout).tap { |logger| logger.level = Logger::DEBUG }
   end


### PR DESCRIPTION
The current version of sucker_punch doesn't support shutting down but v2 (about to be released?) will. Other than that, only the "perform" call will need to change.

I couldn't figure out a good test for the enqueueing, sorry about that. It should be easier with v2.

Note that this hasn't been tested live so it may not work at all! Short on time at the moment.
