### PR TITLE
Pin back EventMachine to ~> 1.0.9 due to ongoing segfault issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * Bugfix: Pin back EventMachine to ~> 1.0.9 due to ongoing segfault issue
 
 # [v1.2.0](https://github.com/adhearsion/blather/compare/v1.1.4...v1.2.0) - [2016-01-07](https://rubygems.org/gems/blather/versions/1.2.0)
   * Bugfix: Properly sort resources with the same priority but different status

--- a/blather.gemspec
+++ b/blather.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = %w{--charset=UTF-8}
   s.extra_rdoc_files = %w{LICENSE README.md}
 
-  s.add_dependency "eventmachine", [">= 1.0.0"]
+  s.add_dependency "eventmachine", ["~> 1.0.9"] # https://github.com/eventmachine/eventmachine/issues/670
   s.add_dependency "nokogiri", ["~> 1.5", ">= 1.5.6", "<= 1.6.1"]
   s.add_dependency "niceogiri", ["~> 1.0"]
   s.add_dependency "activesupport", [">= 2.3.11"]


### PR DESCRIPTION
See eventmachine/eventmachine#670.