### PR TITLE
Unlock Nokogiri to allow >=1.8.3 now that issues are fixed upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby
-  - rbx-2.1.1
+  - 2.3.7
+  - 2.4.4
+  - jruby-9.1.17.0
+  - rbx-3.105
   - ruby-head
+jdk:
+  - openjdk8 # for jruby
 matrix:
   allow_failures:
-    - rvm: jruby
     - rvm: ruby-head
-    - rvm: rbx-2.1.1
+    - rvm: rbx-3.105
 before_install:
   - gem install bundler
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Feature: Bump RSpec to 3.x and convert specs with Transpec
   * Feature: Bump Mocha version to 1.x
   * Feature: Switch from girl_friday to sucker_punch
+  * Feature: Unlock Nokogiri to allow >=1.8.3 now that issues are fixed upstream
 
 # [v1.2.0](https://github.com/adhearsion/blather/compare/v1.1.4...v1.2.0) - [2016-01-07](https://rubygems.org/gems/blather/versions/1.2.0)
   * Bugfix: Properly sort resources with the same priority but different status

--- a/blather.gemspec
+++ b/blather.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w{LICENSE README.md}
 
   s.add_dependency "eventmachine", ["~> 1.2", ">= 1.2.6"]
-  s.add_dependency "nokogiri", ["~> 1.5", ">= 1.5.6", "<= 1.6.1"]
+  s.add_dependency "nokogiri", ["~> 1.8", ">= 1.8.3"]
   s.add_dependency "niceogiri", ["~> 1.0"]
   s.add_dependency "activesupport", [">= 2.3.11"]
   s.add_dependency "sucker_punch", ["~> 2.0"]

--- a/spec/blather/client/client_spec.rb
+++ b/spec/blather/client/client_spec.rb
@@ -158,7 +158,7 @@ describe Blather::Client do
         stream.stubs(:close_connection_after_writing)
         subject.handler_queue.expects(:shutdown)
         subject.close
-        subject.instance_variable_get(:@handler_queue).should be_nil
+        expect(instance_variable_get(:@handler_queue)).to be_nil
       end
 
       it 'forces the work queue to be re-created when referenced' do

--- a/spec/blather/stanza/message_spec.rb
+++ b/spec/blather/stanza/message_spec.rb
@@ -178,7 +178,6 @@ describe Blather::Stanza::Message do
   end
 
   it 'sets valid xhtml even if the input is not valid' do
-    pending "Nokogiri doesn't handle invalid HTML on JRuby" if jruby?
     msg = Blather::Stanza::Message.new
     xhtml = "<some>xhtml"
     msg.xhtml = xhtml

--- a/spec/blather/stream/component_spec.rb
+++ b/spec/blather/stream/component_spec.rb
@@ -68,8 +68,6 @@ describe Blather::Stream::Component do
   end
 
   it 'sends stanzas to the client when the stream is ready' do
-    pending "This hangs the test suite" if jruby?
-
     client.stubs :post_init
     client.expects(:receive_data).with do |n|
       EM.stop

--- a/spec/blather/stream/ssl_spec.rb
+++ b/spec/blather/stream/ssl_spec.rb
@@ -14,7 +14,7 @@ describe Blather::CertStore do
   end
 
   it 'can verify invalid cert' do
-    expect(subject.trusted?(cert[0..(cert.length/2)])).to be_nil
+    expect(subject.trusted?('foo bar baz')).to be_nil
   end
 
   it 'cannot verify when the cert authority is not trusted' do


### PR DESCRIPTION
Yes! Finally! Please let's get a new release out as this addresses some very important security vulnerabilities.