### PR TITLE
Immediately send starttls when server says it's available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * Bugfix: Starttls when offered by server; including when the unsecured stream features start with a <method>
 
 # [v2.0.0](https://github.com/adhearsion/blather/compare/v1.2.0...v2.0.0) - [2018-06-18](https://rubygems.org/gems/blather/versions/2.0.0)
   * Bugfix: Require EventMachine >= 1.2.6 to avoid segfault issue

--- a/lib/blather/stream/features.rb
+++ b/lib/blather/stream/features.rb
@@ -33,7 +33,7 @@ class Stream
       end
 
       @idx = @idx ? @idx+1 : 0
-      if stanza = @features.children[@idx]
+      if stanza = @features.at_xpath("tls:starttls",{"tls" => "urn:ietf:params:xml:ns:xmpp-tls"}) || @features.children[@idx]
         if stanza.namespaces['xmlns'] && (klass = self.class.from_namespace(stanza.namespaces['xmlns']))
           @feature = klass.new(
             @stream,

--- a/spec/blather/stream/client_spec.rb
+++ b/spec/blather/stream/client_spec.rb
@@ -282,7 +282,7 @@ describe Blather::Stream::Client do
       when nil
         state = :started
         server.send_data "<?xml version='1.0'?><stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'>"
-        server.send_data "<stream:features><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' /></stream:features>"
+        server.send_data "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>SCRAM-SHA-1</mechanism></mechanisms><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' /></stream:features>"
         expect(val).to match(/stream:stream/)
 
       when :started


### PR DESCRIPTION
Since some servers offer authentication via SCRAM-SHA-1 before `<starttls>`, and a wider range of authentication mechanisms once tls is enabled; we don't want to close the connection immediately when none of the plaintext authentication methods are supported.

In this pull request I resolve the issue by always attending to `<starttls>` when it's present. This seems to work in practice; but a better approach might be to move it to the front of `<features>` before processing.