### PR TITLE
Starttls first when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
   * Feature: Add Blather::Stanza::Iq::IBR to implement XEP-0077 In-Band Registration
+  * Bugfix: Starttls when offered by server; including when the unsecured stream features start with a <method>
 
 # [v2.0.0](https://github.com/adhearsion/blather/compare/v1.2.0...v2.0.0) - [2018-06-18](https://rubygems.org/gems/blather/versions/2.0.0)
   * Bugfix: Require EventMachine >= 1.2.6 to avoid segfault issue

--- a/lib/blather/stream/features.rb
+++ b/lib/blather/stream/features.rb
@@ -27,9 +27,9 @@ class Stream
 
     def next!
       if starttls = @features.at_xpath("tls:starttls",{"tls" => "urn:ietf:params:xml:ns:xmpp-tls"})
-       @feature = TLS.new(@stream, nil, @fail)
-       @feature.receive_data(starttls)
-       return
+        @feature = TLS.new(@stream, nil, @fail)
+        @feature.receive_data(starttls)
+        return
       end
 
       bind = @features.at_xpath('ns:bind', ns: 'urn:ietf:params:xml:ns:xmpp-bind')

--- a/lib/blather/stream/features.rb
+++ b/lib/blather/stream/features.rb
@@ -26,6 +26,12 @@ class Stream
     end
 
     def next!
+      if starttls = @features.at_xpath("tls:starttls",{"tls" => "urn:ietf:params:xml:ns:xmpp-tls"})
+       @feature = TLS.new(@stream, nil, @fail)
+       @feature.receive_data(starttls)
+       return
+      end
+
       bind = @features.at_xpath('ns:bind', ns: 'urn:ietf:params:xml:ns:xmpp-bind')
       session = @features.at_xpath('ns:session', ns: 'urn:ietf:params:xml:ns:xmpp-session')
       if bind && session && @features.children.last != session
@@ -33,7 +39,7 @@ class Stream
       end
 
       @idx = @idx ? @idx+1 : 0
-      if stanza = @features.at_xpath("tls:starttls",{"tls" => "urn:ietf:params:xml:ns:xmpp-tls"}) || @features.children[@idx]
+      if stanza = @features.children[@idx]
         if stanza.namespaces['xmlns'] && (klass = self.class.from_namespace(stanza.namespaces['xmlns']))
           @feature = klass.new(
             @stream,

--- a/lib/blather/stream/features.rb
+++ b/lib/blather/stream/features.rb
@@ -33,7 +33,7 @@ class Stream
       end
 
       @idx = @idx ? @idx+1 : 0
-      if stanza = @features.children[@idx]
+      if stanza = @features.at_xpath("tls:starttls",{"tls" => "urn:ietf:params:xml:ns:xmpp-tls"}) || @features.children[@idx]
         if stanza.namespaces['xmlns'] && (klass = self.class.from_namespace(stanza.namespaces['xmlns']))
           @feature = klass.new(
             @stream,

--- a/lib/blather/stream/features/tls.rb
+++ b/lib/blather/stream/features/tls.rb
@@ -17,7 +17,6 @@ class Stream
       when 'proceed'
         @stream.start_tls(:verify_peer => true)
         @stream.start
-#        succeed!
       else
         fail! TLSFailure.new
       end

--- a/spec/blather/stream/client_spec.rb
+++ b/spec/blather/stream/client_spec.rb
@@ -282,7 +282,7 @@ describe Blather::Stream::Client do
       when nil
         state = :started
         server.send_data "<?xml version='1.0'?><stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'>"
-        server.send_data "<stream:features><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' /></stream:features>"
+        server.send_data "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>SCRAM-SHA-1</mechanism></mechanisms><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' /></stream:features>"
         expect(val).to match(/stream:stream/)
 
       when :started


### PR DESCRIPTION
Supersedes #168 by pulling the TLS check to the top of the method instead of changing the loop behaviour.

When running a Prosody with `c2s_encryption_required = false` without this patch blather crashes, with it starttls happens as expected.