### PR TITLE
Default messages to no chat state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * No default chat state on new messages, if you want one you need to set it
   * Breaking change (for release in v3.0.0): Blather::Client uses EM.defer instead of sucker_punch for threadpool, or else no threads when passed async: true
   * Bugfix: Blather::Stanza::X#find_or_create only looks at immediate children of parent now
   * Feature: Blather::Stanza::X::Field values can be arrays to support multiple-valued fields

--- a/lib/blather/stanza/message.rb
+++ b/lib/blather/stanza/message.rb
@@ -201,7 +201,6 @@ class Stanza
       node.to = to
       node.type = type
       node.body = body
-      node.chat_state = :active if [:chat, :groupchat].include?(type)
       node
     end
 


### PR DESCRIPTION
Defaulting to active is very unintuitive and results in many blather-based bots
always appearing "active" in clients that show this in their UI, even when that
is not intended or meaningful.  If a developer actually means to have a chat
state, they should set it themselves.