### PR TITLE
No explicit bundler dependency

### DIFF
--- a/blather.gemspec
+++ b/blather.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", [">= 2.3.11"]
   s.add_dependency "sucker_punch", ["~> 2.0"]
 
-  s.add_development_dependency "bundler", ["~> 1.0"]
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ["~> 3.0"]
   s.add_development_dependency "mocha", ["~> 1.0"]


### PR DESCRIPTION
It's not required, and when used it complains about the version
requirement (which isn't needed since there is no code dependency on bundler).