### PR TITLE
Do not change handler behaviour based on return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * Breaking change (for release in v3.0.0): Falsy handler return value no longer causes passing to the next handler. Use `pass` explicitly for that.
   * Breaking change (for release in v3.0.0): Blather::Client uses EM.defer instead of sucker_punch for threadpool, or else no threads when passed async: true
   * Bugfix: Blather::Stanza::X#find_or_create only looks at immediate children of parent now
   * Feature: Blather::Stanza::X::Field values can be arrays to support multiple-valued fields

--- a/spec/blather/client/client_spec.rb
+++ b/spec/blather/client/client_spec.rb
@@ -162,28 +162,34 @@ describe Blather::Client do
     subject.unbind
   end
 
-  it 'calls the :disconnected handler with #unbind is called' do
-    EM.expects(:reactor_running?).returns false
+  it 'does not call EM.stop on #unbind if there is a handler' do
+    EM.expects(:reactor_running?).never
+    EM.expects(:stop).never
     disconnected = mock
     disconnected.expects(:call)
     subject.register_handler(:disconnected) { disconnected.call }
     subject.unbind
   end
 
-  it 'does not call EM.stop on #unbind if a handler returns positive' do
-    EM.expects(:reactor_running?).never
-    EM.expects(:stop).never
-    disconnected = mock
-    disconnected.expects(:call).returns true
-    subject.register_handler(:disconnected) { disconnected.call }
-    subject.unbind
-  end
-
-  it 'calls EM.stop on #unbind if a handler returns negative' do
+  it 'calls EM.stop on #unbind if there is no handler' do
     EM.expects(:reactor_running?).returns true
     EM.expects(:stop)
     disconnected = mock
-    disconnected.expects(:call).returns false
+    subject.unbind
+  end
+
+  it 'does not call EM.stop on #unbind if the reactor is not running' do
+    EM.expects(:reactor_running?).returns false
+    EM.expects(:stop).never
+    disconnected = mock
+    subject.unbind
+  end
+
+  it 'calls EM.stop on #unbind if a handler calls pass' do
+    EM.expects(:reactor_running?).returns true
+    EM.expects(:stop)
+    disconnected = mock
+    disconnected.expects(:call).throws :pass
     subject.register_handler(:disconnected) { disconnected.call }
     subject.unbind
   end


### PR DESCRIPTION
Many normal procedures return nil, so treating a falsy return as a signal to pass on to the next handler is confusing.  A handler can explicitly call/throw pass if they want to pass on down the chain.

Closes #157 