### PR TITLE
Allow jabber:client and jabber:component:accept to appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/blather/compare/master...develop)
+  * jabber:client and jabber:component:accept namespaces are no longer erased when parsing, so if you manually select nodes assuming there will be no namespace for these, you need to update
   * Breaking change (for release in v3.0.0): Blather::Client uses EM.defer instead of sucker_punch for threadpool, or else no threads when passed async: true
   * Bugfix: Blather::Stanza::X#find_or_create only looks at immediate children of parent now
   * Feature: Blather::Stanza::X::Field values can be arrays to support multiple-valued fields

--- a/lib/blather/stream/parser.rb
+++ b/lib/blather/stream/parser.rb
@@ -3,8 +3,6 @@ class Stream
 
   # @private
   class Parser < Nokogiri::XML::SAX::Document
-    NS_TO_IGNORE = %w[jabber:client jabber:component:accept]
-
     @@debug = false
     def self.debug; @@debug; end
     def self.debug=(debug); @@debug = debug; end
@@ -36,7 +34,6 @@ class Stream
       node.document.root = node unless @current
 
       ns_keys = namespaces.map { |pre, href| pre }
-      namespaces.delete_if { |pre, href| NS_TO_IGNORE.include? href }
       @namespace_definitions.push []
       namespaces.each do |pre, href|
         next if @namespace_definitions.flatten.include?(@namespaces[[pre, href]])

--- a/lib/blather/xmpp_node.rb
+++ b/lib/blather/xmpp_node.rb
@@ -31,7 +31,10 @@ module Blather
     # @param [String, nil] xmlns the namespace the node belongs to
     # @return [Class, nil] the class appropriate for the name/ns combination
     def self.class_from_registration(name, ns = nil)
-      @@registrations[[name.to_s, ns]]
+      reg = @@registrations[[name.to_s, ns]]
+      return @@registrations[[name.to_s, nil]] if !reg && ["jabber:client", "jabber:component:accept"].include?(ns)
+
+      reg
     end
 
     # Import an XML::Node to the appropriate class
@@ -85,6 +88,15 @@ module Blather
         @handler_hierarchy.unshift decorator.handler_hierarchy.first if decorator.respond_to?(:handler_hierarchy)
       end
       self
+    end
+
+    def content_from(name, ns = nil)
+      content = super
+      if !content && !ns
+        return super("ns:#{name}", ns: "jabber:client") || super("ns:#{name}", ns: "jabber:component:accept")
+      end
+
+      content
     end
 
     # Turn the object into a proper stanza


### PR DESCRIPTION
With forwarded stanzas (especially for carbons and mam) these may appear more deeply nested and we can't just remove them.