### PR TITLE
Better IDs

### DIFF
--- a/lib/blather/stanza.rb
+++ b/lib/blather/stanza.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 module Blather
 
   # # Base XMPP Stanza
@@ -52,7 +54,7 @@ module Blather
     # @return [String] a new unique ID
     def self.next_id
       @@last_id += 1
-      'blather%04x' % @@last_id
+      "#{SecureRandom.uuid}blather%04x" % @@last_id
     end
 
     # Check if the stanza is an error stanza

--- a/lib/blather/stanza/iq/command.rb
+++ b/lib/blather/stanza/iq/command.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 module Blather
 class Stanza
 class Iq
@@ -116,7 +118,7 @@ class Iq
 
     # Generate a new session ID (SHA-1 hash)
     def new_sessionid!
-      self.sessionid = "commandsession-#{id}"
+      self.sessionid = "#{id}/#{SecureRandom.uuid}"
     end
 
     # Get the action of the command

--- a/lib/blather/stanza/iq/command.rb
+++ b/lib/blather/stanza/iq/command.rb
@@ -111,7 +111,7 @@ class Iq
     #
     # @param [String, nil] sessionid the new sessionid
     def sessionid=(sessionid)
-      command[:sessionid] = Digest::SHA1.hexdigest(sessionid)
+      command[:sessionid] = sessionid
     end
 
     # Generate a new session ID (SHA-1 hash)

--- a/spec/blather/stanza/iq/command_spec.rb
+++ b/spec/blather/stanza/iq/command_spec.rb
@@ -139,7 +139,7 @@ describe Blather::Stanza::Iq::Command do
     n = Blather::Stanza::Iq::Command.new
     expect(n.sessionid).to eq(nil)
     n.sessionid = "somerandomstring"
-    expect(n.sessionid).to eq(Digest::SHA1.hexdigest("somerandomstring"))
+    expect(n.sessionid).to eq("somerandomstring")
   end
 
   it 'has a sessionid? attribute' do


### PR DESCRIPTION
Use UUID as part of stanza and session IDs to make them more unique -- especially needed for message correction XEP or if component restarts while IQs are in flight.