### PR TITLE
Generate Unique Stanza ID

### DIFF
--- a/lib/blather.rb
+++ b/lib/blather.rb
@@ -8,6 +8,7 @@
   digest/sha1
   logger
   openssl
+  securerandom
 
   active_support/core_ext/class/attribute
   active_support/core_ext/object/blank

--- a/lib/blather/stanza.rb
+++ b/lib/blather/stanza.rb
@@ -11,6 +11,8 @@ module Blather
     @@last_id = 0
     # @private
     @@handler_list = []
+    # @private
+    @@id_base = SecureRandom.hex(8)
 
     class_attribute :handler_hierarchy
     attr_writer :handler_hierarchy
@@ -52,7 +54,7 @@ module Blather
     # @return [String] a new unique ID
     def self.next_id
       @@last_id += 1
-      'blather%04x' % @@last_id
+      '%s%04x' % [@@id_base, @@last_id]
     end
 
     # Check if the stanza is an error stanza


### PR DESCRIPTION
I'm using Blather to build a tool that runs periodically, which means it starts up, runs some XMPP commands, and then exits.

This means that my IDs are basically always blather0001, which also means my sessionIDs are basically always the same, which is confusing to the remote side who doesn't know I've restarted and just sees sessionIDs it already knows about, some of which may be ongoing if the script exited in error.

I've tried to make this as minimal of a change as possible because I don't know what lead us to making this choice in the first-place. So there's still just a simple counter, but it's just that the counter is put on the end of a different static string for each run of the script.

I chose 8 hex pairs somewhat arbitrarily because it felt like a round number that was big enough that the liklihood of getting duplicates was vanishingly small, but 4 would have been a more similar length to "blather" which we had before. As it stands, with 8 pairs, the total length of the ID is 20 characters long (4 character counter), which I figure is probably fine.